### PR TITLE
support PUT and PATCH verbs in syntax + Rust server impl

### DIFF
--- a/example/src/api_impl.rs
+++ b/example/src/api_impl.rs
@@ -91,6 +91,24 @@ impl protocol::Godzilla for MonsterApiImpl {
         println!("would delete id={}", id);
         unimplemented!()
     }
+
+    async fn put_monsters_id(
+        &self,
+        monster: protocol::Monster,
+        id: String,
+    ) -> protocol::Response<Result<(), protocol::MonsterError>> {
+        dbg!((id, monster));
+        unimplemented!()
+    }
+
+    async fn patch_monsters_id(
+        &self,
+        patch: protocol::MonsterPatch,
+        id: String,
+    ) -> protocol::Response<Result<(), protocol::MonsterError>> {
+        dbg!((id, patch));
+        unimplemented!()
+    }
 }
 
 /// Implements the `Movies` service (trait `protocol::Movies`)

--- a/humblegen/src/ast.rs
+++ b/humblegen/src/ast.rs
@@ -193,6 +193,28 @@ pub enum ServiceRoute {
         /// The route return type.
         ret: TypeIdent,
     },
+    /// A PUT endpoint.
+    Put {
+        /// The route components. See struct `ServiceRouteComponent`.
+        components: Vec<ServiceRouteComponent>,
+        /// The query type, if specified. (example: `GetMonstersQuery`)
+        query: Option<TypeIdent>,
+        /// The POST body type. (example: `MonsterData`)
+        body: TypeIdent,
+        /// The route return type.
+        ret: TypeIdent,
+    },
+    /// A PATCH endpoint.
+    Patch {
+        /// The route components. See struct `ServiceRouteComponent`.
+        components: Vec<ServiceRouteComponent>,
+        /// The query type, if specified. (example: `GetMonstersQuery`)
+        query: Option<TypeIdent>,
+        /// The POST body type. (example: `MonsterData`)
+        body: TypeIdent,
+        /// The route return type.
+        ret: TypeIdent,
+    },
 }
 
 impl ServiceRoute {
@@ -202,6 +224,8 @@ impl ServiceRoute {
             ServiceRoute::Get { components, .. } => components,
             ServiceRoute::Delete { components, .. } => components,
             ServiceRoute::Post { components, .. } => components,
+            ServiceRoute::Put { components, .. } => components,
+            ServiceRoute::Patch { components, .. } => components,
         }
     }
 
@@ -211,6 +235,8 @@ impl ServiceRoute {
             ServiceRoute::Get { query, .. } => query,
             ServiceRoute::Delete { query, .. } => query,
             ServiceRoute::Post { query, .. } => query,
+            ServiceRoute::Put { query, .. } => query,
+            ServiceRoute::Patch { query, .. } => query,
         }
     }
 
@@ -220,6 +246,8 @@ impl ServiceRoute {
             ServiceRoute::Get { ret, .. } => ret,
             ServiceRoute::Delete { ret, .. } => ret,
             ServiceRoute::Post { ret, .. } => ret,
+            ServiceRoute::Put { ret, .. } => ret,
+            ServiceRoute::Patch { ret, .. } => ret,
         }
     }
 }

--- a/humblegen/src/humble.pest
+++ b/humblegen/src/humble.pest
@@ -45,9 +45,11 @@ http_query = !{ "?" ~ open_curly ~ type_ident ~ close_curly }
 http_get = { "GET" }
 http_post = { "POST" }
 http_delete = { "DELETE" }
+http_put = { "PUT" }
+http_patch = { "PATCH" }
 service_rule = { doc_comment? ~ service_rule_def }
 service_rule_def = {
-    http_post ~ http_route ~ http_query? ~ "->" ~ type_ident ~ "->" ~ type_ident |
+    ( http_post | http_put | http_patch ) ~ http_route ~ http_query? ~ "->" ~ type_ident ~ "->" ~ type_ident |
     ( http_get | http_delete ) ~ http_route ~ http_query? ~ "->" ~ type_ident
 }
 

--- a/humblegen/src/parser.rs
+++ b/humblegen/src/parser.rs
@@ -203,6 +203,8 @@ fn parse_service_rule_def(pair: pest::iterators::Pair<Rule>) -> ServiceRoute {
         Rule::http_get => parse_service_rule_get,
         Rule::http_delete => parse_service_rule_delete,
         Rule::http_post => parse_service_rule_post,
+        Rule::http_put => parse_service_rule_put,
+        Rule::http_patch => parse_service_rule_patch,
         x => panic!("unexpected token {:?}", x),
     };
     nodes.next().unwrap(); // consume what we peeked
@@ -229,6 +231,24 @@ fn parse_service_rule_delete(pair: &mut pest::iterators::Pairs<Rule>) -> Service
 
 fn parse_service_rule_post(pair: &mut pest::iterators::Pairs<Rule>) -> ServiceRoute {
     ServiceRoute::Post {
+        components: parse_http_route(pair.next().unwrap()),
+        query: parse_http_query(pair),
+        body: parse_type_ident(pair.next().unwrap()),
+        ret: parse_type_ident(pair.next().unwrap()),
+    }
+}
+
+fn parse_service_rule_put(pair: &mut pest::iterators::Pairs<Rule>) -> ServiceRoute {
+    ServiceRoute::Put {
+        components: parse_http_route(pair.next().unwrap()),
+        query: parse_http_query(pair),
+        body: parse_type_ident(pair.next().unwrap()),
+        ret: parse_type_ident(pair.next().unwrap()),
+    }
+}
+
+fn parse_service_rule_patch(pair: &mut pest::iterators::Pairs<Rule>) -> ServiceRoute {
+    ServiceRoute::Patch {
         components: parse_http_route(pair.next().unwrap()),
         query: parse_http_query(pair),
         body: parse_type_ident(pair.next().unwrap()),

--- a/humblegen/src/rust/service_server.rs
+++ b/humblegen/src/rust/service_server.rs
@@ -443,6 +443,8 @@ fn lower_service_route(endpoint: &ast::ServiceEndpoint) -> ServiceRoute {
         ast::ServiceRoute::Get { .. } => None,
         ast::ServiceRoute::Delete { .. } => None,
         ast::ServiceRoute::Post { body, .. } => Some(render_type_ident(body)),
+        ast::ServiceRoute::Put { body, .. } => Some(render_type_ident(body)),
+        ast::ServiceRoute::Patch { body, .. } => Some(render_type_ident(body)),
     };
 
     let ret_type = render_type_ident(endpoint.route.return_type());
@@ -477,6 +479,8 @@ fn lower_service_route(endpoint: &ast::ServiceEndpoint) -> ServiceRoute {
             ("delete", quote!(::humblegen_rt::hyper::Method::DELETE))
         }
         ast::ServiceRoute::Post { .. } => ("post", quote!(::humblegen_rt::hyper::Method::POST)),
+        ast::ServiceRoute::Put { .. } => ("put", quote!(::humblegen_rt::hyper::Method::PUT)),
+        ast::ServiceRoute::Patch { .. } => ("patch", quote!(::humblegen_rt::hyper::Method::PATCH)),
     };
     let traitfn_ident = format_ident!(
         "{}_{}",

--- a/humblegen/tests/rust/service/spec.humble
+++ b/humblegen/tests/rust/service/spec.humble
@@ -22,6 +22,14 @@ struct MonsterData2 {
     .. MonsterData3,
 }
 
+/// patch of a monster
+struct MonsterPatch {
+    name: option[str],
+    hp: option[i32],   
+    foo: option[str],
+}
+
+
 struct MonsterData3 {
     bar: str
 }
@@ -57,6 +65,12 @@ service Godzilla {
 
     /// Create a new monster.
     POST /monsters -> MonsterData -> result[Monster][MonsterError],
+
+    /// Overwrite a monster.
+    PUT /monsters/{id: str} -> Monster -> result[()][MonsterError],
+
+    /// Patch a monster.
+    PATCH /monsters/{id: str} -> MonsterPatch -> result[()][MonsterError],
 
     /// Delete a monster
     DELETE /monster/{id: str} -> result[()][MonsterError],

--- a/humblegen/tests/rust/service/spec.rs
+++ b/humblegen/tests/rust/service/spec.rs
@@ -29,6 +29,16 @@ pub struct MonsterData2 {
     pub bar: String,
 }
 #[derive(Debug, Clone, serde :: Deserialize, serde :: Serialize)]
+#[doc = "patch of a monster"]
+pub struct MonsterPatch {
+    #[doc = ""]
+    pub name: Option<String>,
+    #[doc = ""]
+    pub hp: Option<i32>,
+    #[doc = ""]
+    pub foo: Option<String>,
+}
+#[derive(Debug, Clone, serde :: Deserialize, serde :: Serialize)]
 #[doc = ""]
 pub struct MonsterData3 {
     #[doc = ""]
@@ -143,40 +153,54 @@ impl std::fmt::Debug for Handler {
     }
 }
 #[doc = "service Godzilla provides services related to monsters."]
-#[doc = "```\n# [ humblegen_rt :: async_trait ( Sync ) ] pub trait Godzilla { # [ doc = \"```\\nasync fn get_foo ( & self , ) -> Response < u32 >\\n```\" ] # [ doc = \"Get foo.\" ] async fn get_foo ( & self , ) -> Response < u32 > ; # [ doc = \"```\\nasync fn get_monsters_id ( & self , id : String , ) -> Response < Result < Monster , MonsterError > >\\n```\" ] # [ doc = \"Get monster by id\" ] async fn get_monsters_id ( & self , id : String , ) -> Response < Result < Monster , MonsterError > > ; # [ doc = \"```\\nasync fn get_monsters ( & self , query : Option < MonsterQuery > , ) -> Response < Vec < Monster > >\\n```\" ] # [ doc = \"Get monster by posting a query\" ] async fn get_monsters ( & self , query : Option < MonsterQuery > , ) -> Response < Vec < Monster > > ; # [ doc = \"```\\nasync fn get_monsters_2 ( & self , query : Option < String > , ) -> Response < Vec < Monster > >\\n```\" ] # [ doc = \"\" ] async fn get_monsters_2 ( & self , query : Option < String > , ) -> Response < Vec < Monster > > ; # [ doc = \"```\\nasync fn get_monsters_3 ( & self , query : Option < i32 > , ) -> Response < Vec < Monster > >\\n```\" ] # [ doc = \"\" ] async fn get_monsters_3 ( & self , query : Option < i32 > , ) -> Response < Vec < Monster > > ; # [ doc = \"```\\nasync fn get_monsters_4 ( & self , ) -> Response < Vec < Monster > >\\n```\" ] # [ doc = \"\" ] async fn get_monsters_4 ( & self , ) -> Response < Vec < Monster > > ; # [ doc = \"```\\nasync fn post_monsters ( & self , post_body : MonsterData , ) -> Response < Result < Monster , MonsterError > >\\n```\" ] # [ doc = \"Create a new monster.\" ] async fn post_monsters ( & self , post_body : MonsterData , ) -> Response < Result < Monster , MonsterError > > ; # [ doc = \"```\\nasync fn delete_monster_id ( & self , id : String , ) -> Response < Result < ( ) , MonsterError > >\\n```\" ] # [ doc = \"Delete a monster\" ] async fn delete_monster_id ( & self , id : String , ) -> Response < Result < ( ) , MonsterError > > ; # [ doc = \"```\\nasync fn get_version ( & self , ) -> Response < String >\\n```\" ] # [ doc = \"\" ] async fn get_version ( & self , ) -> Response < String > ; # [ doc = \"```\\nasync fn get_tokio_police_locations ( & self , ) -> Response < Result < Vec < PoliceCar > , PoliceError > >\\n```\" ] # [ doc = \"\" ] async fn get_tokio_police_locations ( & self , ) -> Response < Result < Vec < PoliceCar > , PoliceError > > ; }\n```"]
+#[doc = "```\n#[humblegen_rt::async_trait(Sync)]\npub trait Godzilla {\n    async fn get_foo(&self) -> Response<u32>;\n    async fn get_monsters_id(&self, id: String) -> Response<Result<Monster, MonsterError>>;\n    async fn get_monsters(&self, query: Option<MonsterQuery>) -> Response<Vec<Monster>>;\n    async fn get_monsters_2(&self, query: Option<String>) -> Response<Vec<Monster>>;\n    async fn get_monsters_3(&self, query: Option<i32>) -> Response<Vec<Monster>>;\n    async fn get_monsters_4(&self) -> Response<Vec<Monster>>;\n    async fn post_monsters(\n        &self,\n        post_body: MonsterData,\n    ) -> Response<Result<Monster, MonsterError>>;\n    async fn put_monsters_id(\n        &self,\n        post_body: Monster,\n        id: String,\n    ) -> Response<Result<(), MonsterError>>;\n    async fn patch_monsters_id(\n        &self,\n        post_body: MonsterPatch,\n        id: String,\n    ) -> Response<Result<(), MonsterError>>;\n    async fn delete_monster_id(&self, id: String) -> Response<Result<(), MonsterError>>;\n    async fn get_version(&self) -> Response<String>;\n    async fn get_tokio_police_locations(&self) -> Response<Result<Vec<PoliceCar>, PoliceError>>;\n}\n\n```"]
 #[humblegen_rt::async_trait(Sync)]
 pub trait Godzilla {
-    #[doc = "```\nasync fn get_foo ( & self , ) -> Response < u32 >\n```"]
+    #[doc = "```\nasync fn get_foo(&self) -> Response<u32> {}\n\n```"]
     #[doc = "Get foo."]
     async fn get_foo(&self) -> Response<u32>;
-    #[doc = "```\nasync fn get_monsters_id ( & self , id : String , ) -> Response < Result < Monster , MonsterError > >\n```"]
+    #[doc = "```\nasync fn get_monsters_id(&self, id: String) -> Response<Result<Monster, MonsterError>> {}\n\n```"]
     #[doc = "Get monster by id"]
     async fn get_monsters_id(&self, id: String) -> Response<Result<Monster, MonsterError>>;
-    #[doc = "```\nasync fn get_monsters ( & self , query : Option < MonsterQuery > , ) -> Response < Vec < Monster > >\n```"]
+    #[doc = "```\nasync fn get_monsters(&self, query: Option<MonsterQuery>) -> Response<Vec<Monster>> {}\n\n```"]
     #[doc = "Get monster by posting a query"]
     async fn get_monsters(&self, query: Option<MonsterQuery>) -> Response<Vec<Monster>>;
-    #[doc = "```\nasync fn get_monsters_2 ( & self , query : Option < String > , ) -> Response < Vec < Monster > >\n```"]
+    #[doc = "```\nasync fn get_monsters_2(&self, query: Option<String>) -> Response<Vec<Monster>> {}\n\n```"]
     #[doc = ""]
     async fn get_monsters_2(&self, query: Option<String>) -> Response<Vec<Monster>>;
-    #[doc = "```\nasync fn get_monsters_3 ( & self , query : Option < i32 > , ) -> Response < Vec < Monster > >\n```"]
+    #[doc = "```\nasync fn get_monsters_3(&self, query: Option<i32>) -> Response<Vec<Monster>> {}\n\n```"]
     #[doc = ""]
     async fn get_monsters_3(&self, query: Option<i32>) -> Response<Vec<Monster>>;
-    #[doc = "```\nasync fn get_monsters_4 ( & self , ) -> Response < Vec < Monster > >\n```"]
+    #[doc = "```\nasync fn get_monsters_4(&self) -> Response<Vec<Monster>> {}\n\n```"]
     #[doc = ""]
     async fn get_monsters_4(&self) -> Response<Vec<Monster>>;
-    #[doc = "```\nasync fn post_monsters ( & self , post_body : MonsterData , ) -> Response < Result < Monster , MonsterError > >\n```"]
+    #[doc = "```\nasync fn post_monsters(&self, post_body: MonsterData) -> Response<Result<Monster, MonsterError>> {}\n\n```"]
     #[doc = "Create a new monster."]
     async fn post_monsters(
         &self,
         post_body: MonsterData,
     ) -> Response<Result<Monster, MonsterError>>;
-    #[doc = "```\nasync fn delete_monster_id ( & self , id : String , ) -> Response < Result < ( ) , MonsterError > >\n```"]
+    #[doc = "```\nasync fn put_monsters_id(\n    &self,\n    post_body: Monster,\n    id: String,\n) -> Response<Result<(), MonsterError>> {\n}\n\n```"]
+    #[doc = "Overwrite a monster."]
+    async fn put_monsters_id(
+        &self,
+        post_body: Monster,
+        id: String,
+    ) -> Response<Result<(), MonsterError>>;
+    #[doc = "```\nasync fn patch_monsters_id(\n    &self,\n    post_body: MonsterPatch,\n    id: String,\n) -> Response<Result<(), MonsterError>> {\n}\n\n```"]
+    #[doc = "Patch a monster."]
+    async fn patch_monsters_id(
+        &self,
+        post_body: MonsterPatch,
+        id: String,
+    ) -> Response<Result<(), MonsterError>>;
+    #[doc = "```\nasync fn delete_monster_id(&self, id: String) -> Response<Result<(), MonsterError>> {}\n\n```"]
     #[doc = "Delete a monster"]
     async fn delete_monster_id(&self, id: String) -> Response<Result<(), MonsterError>>;
-    #[doc = "```\nasync fn get_version ( & self , ) -> Response < String >\n```"]
+    #[doc = "```\nasync fn get_version(&self) -> Response<String> {}\n\n```"]
     #[doc = ""]
     async fn get_version(&self) -> Response<String>;
-    #[doc = "```\nasync fn get_tokio_police_locations ( & self , ) -> Response < Result < Vec < PoliceCar > , PoliceError > >\n```"]
+    #[doc = "```\nasync fn get_tokio_police_locations(&self) -> Response<Result<Vec<PoliceCar>, PoliceError>> {}\n\n```"]
     #[doc = ""]
     async fn get_tokio_police_locations(&self) -> Response<Result<Vec<PoliceCar>, PoliceError>>;
 }
@@ -333,6 +357,56 @@ fn routes_Godzilla(handler: Arc<dyn Godzilla + Send + Sync>) -> Vec<Route> {
         {
             let handler = Arc::clone(&handler);
             Route {
+                method: ::humblegen_rt::hyper::Method::PUT,
+                regex: ::humblegen_rt::regex::Regex::new("^/monsters/(?P<id>[^/]+)$").unwrap(),
+                dispatcher: Box::new(
+                    move |mut req: ::humblegen_rt::hyper::Request<::humblegen_rt::hyper::Body>,
+                          captures| {
+                        let handler = Arc::clone(&handler);
+                        let id: String = {
+                            |s| {
+                                ::std::primitive::str::parse(s)
+                                    .expect("regex should prevent parse errors")
+                            }
+                        }(&captures["id"]);
+                        Box::pin(async move {
+                            let post_body: Monster = deser_post_data(req.body_mut()).await?;
+                            Ok(handler_response_to_hyper_response(
+                                handler.put_monsters_id(post_body, id).await,
+                            ))
+                        })
+                    },
+                ),
+            }
+        },
+        {
+            let handler = Arc::clone(&handler);
+            Route {
+                method: ::humblegen_rt::hyper::Method::PATCH,
+                regex: ::humblegen_rt::regex::Regex::new("^/monsters/(?P<id>[^/]+)$").unwrap(),
+                dispatcher: Box::new(
+                    move |mut req: ::humblegen_rt::hyper::Request<::humblegen_rt::hyper::Body>,
+                          captures| {
+                        let handler = Arc::clone(&handler);
+                        let id: String = {
+                            |s| {
+                                ::std::primitive::str::parse(s)
+                                    .expect("regex should prevent parse errors")
+                            }
+                        }(&captures["id"]);
+                        Box::pin(async move {
+                            let post_body: MonsterPatch = deser_post_data(req.body_mut()).await?;
+                            Ok(handler_response_to_hyper_response(
+                                handler.patch_monsters_id(post_body, id).await,
+                            ))
+                        })
+                    },
+                ),
+            }
+        },
+        {
+            let handler = Arc::clone(&handler);
+            Route {
                 method: ::humblegen_rt::hyper::Method::DELETE,
                 regex: ::humblegen_rt::regex::Regex::new("^/monster/(?P<id>[^/]+)$").unwrap(),
                 dispatcher: Box::new(
@@ -393,7 +467,7 @@ fn routes_Godzilla(handler: Arc<dyn Godzilla + Send + Sync>) -> Vec<Route> {
     ]
 }
 #[doc = ""]
-#[doc = "```\n# [ humblegen_rt :: async_trait ( Sync ) ] pub trait Movies { }\n```"]
+#[doc = "```\n#[humblegen_rt::async_trait(Sync)]\npub trait Movies {}\n\n```"]
 #[humblegen_rt::async_trait(Sync)]
 pub trait Movies {}
 #[allow(unused_variables)]

--- a/humblespec/humblespec.md
+++ b/humblespec/humblespec.md
@@ -18,12 +18,12 @@ This document describes the humblespec language.
 
 A service definition defines a set of endpoints.
 An endpoint is comprised of
-* a **method** (GET, POST)
+* a **method** (`GET`, `POST`, `DELETE`, `PUT`, `PATCH`)
 * a **route** consisting of slash-separated **route components**, which can be
   * a literal route component (kebab-case)
   * a parameter that can be deserialized from a string that does not contain a slash
 * an optional **query** type specified by `?{`*`StructType`*`}`
-* for `POST` requests, a **body type**
+* for `POST`, `PUT`, and `PATCH` requests, a **body type**
 * a **response type**
 
 **Example:**


### PR DESCRIPTION
@mbr please have a look at the method signatures in 

- [ ] `ast::ServiceRoute` should probably be a `struct` since most request types have the same fields => separate issue
- [ ] discuss whether auto-deriving a `PATCH` body type makes sense, a la:
   ```
   /// the GET return type and PUT body type
   struct Monster {
       id: i32,
       .. MonsterData,
   }
   
   /// the POST body type
   struct MonsterData {
       name: str,
       hp: i32,
       color: Color,
   }
   
   /// the PATCH body type
   struct MonsterPatch {
       ?? Monster,
   }
   ```
  (the `??` is obviously up for debate)