### PR TITLE
rust server: support for trait method that intercepts requests (use case: auth)

### DIFF
--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -334,6 +334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,11 +453,14 @@ dependencies = [
  "hyper",
  "lazy_static",
  "log",
+ "rand",
  "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -737,6 +751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +784,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -944,6 +1005,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
+name = "tracing"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1113,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "which"

--- a/example/src/api_impl.rs
+++ b/example/src/api_impl.rs
@@ -12,7 +12,9 @@ pub struct MonsterApiImpl {
 
 #[async_trait(Sync)]
 impl protocol::Godzilla for MonsterApiImpl {
-    async fn get_foo(&self) -> protocol::Response<u32> {
+    type Context = ();
+
+    async fn get_foo(&self, _ctx: Self::Context) -> protocol::Response<u32> {
         // simulate authorization failure for every other request
         let v = self.ctr.fetch_add(1, SeqCst);
         if v % 2 == 0 {
@@ -24,6 +26,7 @@ impl protocol::Godzilla for MonsterApiImpl {
 
     async fn get_monsters_id(
         &self,
+        _ctx: Self::Context,
         _id: i32,
     ) -> protocol::Response<Result<protocol::Monster, protocol::MonsterError>> {
         // demonstrate how service-specific errors are handled
@@ -32,6 +35,7 @@ impl protocol::Godzilla for MonsterApiImpl {
 
     async fn get_monsters(
         &self,
+        _ctx: Self::Context,
         query: Option<protocol::MonsterQuery>,
     ) -> protocol::Response<Vec<protocol::Monster>> {
         // the query-part of the URL is deserialized into argument `query` if specified by the user
@@ -43,6 +47,7 @@ impl protocol::Godzilla for MonsterApiImpl {
 
     async fn post_monsters(
         &self,
+        _ctx: Self::Context,
         post_body: protocol::MonsterData,
     ) -> protocol::Response<Result<protocol::Monster, protocol::MonsterError>> {
         // the POST body is made available as argument `post_body`
@@ -55,6 +60,7 @@ impl protocol::Godzilla for MonsterApiImpl {
 
     async fn get_monsters_2(
         &self,
+        _ctx: Self::Context,
         query: Option<String>,
     ) -> protocol::Response<Vec<protocol::Monster>> {
         dbg!(query);
@@ -63,6 +69,7 @@ impl protocol::Godzilla for MonsterApiImpl {
 
     async fn get_monsters_3(
         &self,
+        _ctx: Self::Context,
         query: Option<i32>,
     ) -> protocol::Response<Vec<protocol::Monster>> {
         // non-struct queries are deserialized
@@ -70,22 +77,27 @@ impl protocol::Godzilla for MonsterApiImpl {
         unimplemented!()
     }
 
-    async fn get_monsters_4(&self) -> protocol::Response<Vec<protocol::Monster>> {
+    async fn get_monsters_4(
+        &self,
+        _ctx: Self::Context,
+    ) -> protocol::Response<Vec<protocol::Monster>> {
         unimplemented!()
     }
 
-    async fn get_version(&self) -> protocol::Response<String> {
+    async fn get_version(&self, _ctx: Self::Context) -> protocol::Response<String> {
         unimplemented!()
     }
 
     async fn get_tokio_police_locations(
         &self,
+        _ctx: Self::Context,
     ) -> protocol::Response<Result<Vec<protocol::PoliceCar>, protocol::PoliceError>> {
         unimplemented!()
     }
 
     async fn delete_monster_id(
         &self,
+        _ctx: Self::Context,
         id: String,
     ) -> protocol::Response<Result<(), protocol::MonsterError>> {
         println!("would delete id={}", id);
@@ -94,6 +106,7 @@ impl protocol::Godzilla for MonsterApiImpl {
 
     async fn put_monsters_id(
         &self,
+        _ctx: Self::Context,
         monster: protocol::Monster,
         id: String,
     ) -> protocol::Response<Result<(), protocol::MonsterError>> {
@@ -103,6 +116,7 @@ impl protocol::Godzilla for MonsterApiImpl {
 
     async fn patch_monsters_id(
         &self,
+        _ctx: Self::Context,
         patch: protocol::MonsterPatch,
         id: String,
     ) -> protocol::Response<Result<(), protocol::MonsterError>> {
@@ -115,4 +129,6 @@ impl protocol::Godzilla for MonsterApiImpl {
 #[derive(Default)]
 pub struct MoviesApiImpl {}
 
-impl protocol::Movies for MoviesApiImpl {}
+impl protocol::Movies for MoviesApiImpl {
+    type Context = ();
+}

--- a/humblegen-rt/src/service_protocol.rs
+++ b/humblegen-rt/src/service_protocol.rs
@@ -14,7 +14,7 @@ pub struct ErrorResponse {
     pub kind: ErrorResponseKind,
 }
 
-pub(crate) trait ToErrorResponse {
+pub trait ToErrorResponse {
     fn to_error_response(self) -> ErrorResponse;
 }
 

--- a/humblegen/tests/rust/service-authorization-using-interceptor/main.rs
+++ b/humblegen/tests/rust/service-authorization-using-interceptor/main.rs
@@ -1,0 +1,67 @@
+mod protocol {
+    include!("spec.rs");
+}
+use humblegen_rt::hyper;
+use protocol::*;
+use std::sync::Arc;
+
+struct S;
+
+#[derive(Default)]
+struct AuthzScope {
+    user_id: String,
+    posting_allowed: bool,
+}
+
+#[humblegen_rt::async_trait(Sync)]
+impl BlogApi for S {
+    type Context = AuthzScope;
+
+    async fn intercept_handler_pre(
+        &self,
+        req: &hyper::Request<hyper::Body>,
+    ) -> Result<Self::Context, ServiceError> {
+        if req
+            .headers()
+            .get(hyper::header::AUTHORIZATION)
+            .ok_or(ServiceError::Authorization)?
+            .to_str()
+            .map_err(|_| ServiceError::Authorization)?
+            == "Custom AUTHZ_TOKEN"
+        {
+            // .. find user id database ...
+            Ok(AuthzScope {
+                user_id: "alice".to_owned(),
+                posting_allowed: true,
+            })
+        } else {
+            Err(ServiceError::Authorization)
+        }
+    }
+
+    async fn post_user_posts(
+        &self,
+        ctx: Self::Context,
+        post_body: Post,
+        user: String,
+    ) -> Response<Post> {
+        if user != ctx.user_id {
+            return Err(ServiceError::Authorization);
+        }
+        if !ctx.posting_allowed {
+            return Err(ServiceError::Authorization);
+        }
+        // store user's post in the database
+        println!("user {:?} posted {:?}", user, post_body);
+        Ok(post_body)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // let listen_addr: std::net::SocketAddr = "127.0.0.1:3000".parse().unwrap();
+    Builder::new().add("/api", Handler::BlogApi(Arc::new(S)));
+    // .listen_and_run_forever(&listen_addr)
+    // .await
+    // .unwrap();
+}

--- a/humblegen/tests/rust/service-authorization-using-interceptor/spec.humble
+++ b/humblegen/tests/rust/service-authorization-using-interceptor/spec.humble
@@ -1,0 +1,9 @@
+struct Post {
+    content: str
+}
+
+service BlogApi {
+    /// Must send header `Authorization: Custom AUTHZ_TOKEN`
+    /// otherwise authorization error.
+    POST /{user: str}/posts -> Post -> Post,
+}

--- a/humblegen/tests/rust/service-authorization-using-interceptor/spec.rs
+++ b/humblegen/tests/rust/service-authorization-using-interceptor/spec.rs
@@ -1,0 +1,151 @@
+#[derive(Debug, Clone, serde :: Deserialize, serde :: Serialize)]
+#[doc = ""]
+pub struct Post {
+    #[doc = ""]
+    pub content: String,
+}
+#[allow(unused_imports)]
+use ::humblegen_rt::deser_helpers::{
+    deser_param, deser_post_data, deser_query_primitive, deser_query_serde_urlencoded,
+};
+#[allow(unused_imports)]
+pub use ::humblegen_rt::handler::{self, HandlerResponse as Response, ServiceError};
+#[allow(unused_imports)]
+use ::humblegen_rt::hyper;
+#[allow(unused_imports)]
+use ::humblegen_rt::regexset_map::RegexSetMap;
+#[allow(unused_imports)]
+use ::humblegen_rt::server::{self, handler_response_to_hyper_response, Route, Service};
+#[allow(unused_imports)]
+use ::humblegen_rt::service_protocol::ErrorResponse;
+#[allow(unused_imports)]
+use ::std::sync::Arc;
+use std::net::SocketAddr;
+#[doc = r" Builds an HTTP server that exposes services implemented by handler trait objects."]
+#[derive(Debug)]
+pub struct Builder {
+    services: Vec<Service>,
+}
+impl Builder {
+    pub fn new() -> Self {
+        Self { services: vec![] }
+    }
+    #[doc = r" Mounts `handler` at URL path prefix `root`."]
+    #[doc = r" This means that a `handler` implementing humble service"]
+    #[doc = r" ```"]
+    #[doc = r" service S {"]
+    #[doc = r"     GET /bar -> i32,"]
+    #[doc = r"     GET /baz -> str,"]
+    #[doc = r" }"]
+    #[doc = r" ```"]
+    #[doc = r#" and `root="/api"` will expose"#]
+    #[doc = r" * handler method `fn bar() -> i32` at `/api/bar` and"]
+    #[doc = r" * handler method `fn baz() -> String` at `/api/baz`"]
+    pub fn add<Context: Default + Sized + Send + Sync>(
+        mut self,
+        root: &str,
+        handler: Handler<Context>,
+    ) -> Self {
+        if !root.starts_with('/') {
+            panic!("root must start with \"/\"")
+        } else if root.ends_with('/') {
+            panic!("root must not end with \"/\"")
+        }
+        let routes: Vec<Route> = handler.into_routes();
+        let routes = RegexSetMap::new(routes).unwrap();
+        self.services.push(Service((
+            humblegen_rt::regex::Regex::new(&format!(r"^(?P<root>{})(?P<suffix>/.*)", root))
+                .unwrap(),
+            routes,
+        )));
+        self
+    }
+    #[doc = r" Starts an HTTP server bound to address `addr` and serves incoming requests using"]
+    #[doc = r" the previously `add`ed handlers."]
+    pub async fn listen_and_run_forever(
+        self,
+        addr: &SocketAddr,
+    ) -> humblegen_rt::anyhow::Result<()> {
+        use humblegen_rt::anyhow::Context;
+        let services = RegexSetMap::new(self.services).context("invalid service configuration")?;
+        server::listen_and_run_forever(services, addr).await
+    }
+}
+#[doc = r" Wrapper enum with one variant for each service defined in the humble spec."]
+#[doc = r" Used to pass instantiated handler trait objects to `Builder::add`."]
+#[allow(dead_code)]
+pub enum Handler<Context: Default + Sized + Send + Sync + 'static> {
+    BlogApi(Arc<dyn BlogApi<Context = Context> + Send + Sync>),
+}
+impl<Context: Default + Sized + Send + Sync + 'static> Handler<Context> {
+    fn into_routes(self) -> Vec<Route> {
+        match self {
+            Handler::BlogApi(h) => routes_BlogApi(h),
+        }
+    }
+}
+impl<Context: Default + Sized + Send + Sync + 'static> std::fmt::Debug for Handler<Context> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Handler::BlogApi(_) => write!(formatter, "{}", "BlogApi")?,
+        }
+        Ok(())
+    }
+}
+#[doc = ""]
+#[doc = "```\n#[humblegen_rt::async_trait(Sync)]\npub trait BlogApi {\n    type Context: Default + Sized + Send + Sync;\n    async fn intercept_handler_pre(\n        &self,\n        _req: &hyper::Request<hyper::Body>,\n    ) -> Result<Self::Context, ServiceError> {\n        Ok(Self::Context::default())\n    }\n    async fn post_user_posts(\n        &self,\n        ctx: Self::Context,\n        post_body: Post,\n        user: String,\n    ) -> Response<Post>;\n}\n\n```"]
+#[humblegen_rt::async_trait(Sync)]
+pub trait BlogApi {
+    type Context: Default + Sized + Send + Sync;
+    async fn intercept_handler_pre(
+        &self,
+        _req: &hyper::Request<hyper::Body>,
+    ) -> Result<Self::Context, ServiceError> {
+        Ok(Self::Context::default())
+    }
+    #[doc = "```\nasync fn post_user_posts(\n    &self,\n    ctx: Self::Context,\n    post_body: Post,\n    user: String,\n) -> Response<Post> {\n}\n\n```"]
+    #[doc = "Must send header `Authorization: Custom AUTHZ_TOKEN`\notherwise authorization error."]
+    async fn post_user_posts(
+        &self,
+        ctx: Self::Context,
+        post_body: Post,
+        user: String,
+    ) -> Response<Post>;
+}
+#[allow(unused_variables)]
+#[allow(unused_mut)]
+#[allow(non_snake_case)]
+#[allow(clippy::trivial_regex)]
+#[allow(clippy::single_char_pattern)]
+fn routes_BlogApi<Context: Default + Sized + Send + Sync + 'static>(
+    handler: Arc<dyn BlogApi<Context = Context> + Send + Sync>,
+) -> Vec<Route> {
+    vec![{
+        let handler = Arc::clone(&handler);
+        Route {
+            method: ::humblegen_rt::hyper::Method::POST,
+            regex: ::humblegen_rt::regex::Regex::new("^/(?P<user>[^/]+)/posts$").unwrap(),
+            dispatcher: Box::new(
+                move |mut req: ::humblegen_rt::hyper::Request<::humblegen_rt::hyper::Body>,
+                      captures| {
+                    let handler = Arc::clone(&handler);
+                    let user: Result<String, ErrorResponse> =
+                        deser_param("user", &captures["user"]);
+                    Box::pin(async move {
+                        let user = user?;
+                        let post_body: Post = deser_post_data(req.body_mut()).await?;
+                        use ::humblegen_rt::service_protocol::ToErrorResponse;
+                        let ctx = handler
+                            .intercept_handler_pre(&req)
+                            .await
+                            .map_err(::humblegen_rt::service_protocol::ServiceError::from)
+                            .map_err(|e| e.to_error_response())?;
+                        Ok(handler_response_to_hyper_response(
+                            handler.post_user_posts(ctx, post_body, user).await,
+                        ))
+                    })
+                },
+            ),
+        }
+    }]
+}


### PR DESCRIPTION


* The handler trait gets an additional method `intercept_handler_pre(&self, &req, ctx)`
* `ctx` is an associated type of the handler trait
* `ctx`'s role is to store data extracted by the interceptor

Check out the newly added example `humblegen/tests/rust/service-authorization-using-interceptor`.

- [ ] Problem: I do not know how I should deal with this warning:

```
WARNINGS:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
warning: the trait `protocol::BlogApi` cannot be made into an object
   --> $DIR/spec.rs:100:14
    |
98  | pub trait BlogApi {
    |           ------- this trait cannot be made into an object...
99  |     type Context: Default + Sized + Send + Sync;
100 |     async fn intercept_handler_pre(
    |              ^^^^^^^^^^^^^^^^^^^^^ ...because method `intercept_handler_pre` references the `Self` type in its `where` clause
    |
    = note: `#[warn(where_clauses_object_safety)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
    = help: consider moving `intercept_handler_pre` to another trait
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```

ISTM that it is related to `async-trait` because it goes away if we remove the `async` in front of the `async fn intercept_handler_pre` decl.