### PR TITLE
replace argh cli parsing with structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,35 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
-name = "argh"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1877e24cecacd700d469066e0160c4f8497cc5635367163f50c8beec820154"
-dependencies = [
- "argh_derive",
- "argh_shared",
-]
-
-[[package]]
-name = "argh_derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e742194e0f43fc932bcb801708c2b279d3ec8f527e3acda05a6a9f342c5ef764"
-dependencies = [
- "argh_shared",
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "argh_shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ba68f4276a778591e36a0c348a269888f3a177c8d2054969389e3b59611ff5"
-
-[[package]]
 name = "async-trait-with-sync"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,7 +498,6 @@ version = "0.3.2"
 dependencies = [
  "Inflector",
  "anyhow",
- "argh",
  "async-trait-with-sync",
  "base64",
  "comrak",
@@ -540,6 +510,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
+ "structopt",
  "syn",
  "tempfile",
  "thiserror",
@@ -920,6 +891,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1148,30 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1468,6 +1487,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "want"

--- a/humblegen/Cargo.toml
+++ b/humblegen/Cargo.toml
@@ -12,19 +12,19 @@ description = "An experimental code-generator in the vain of protobuf, but a lit
 
 [dependencies]
 Inflector = "0.11.4"
+anyhow = "1.0"
+base64 = "0.12.1"
+comrak = "0.7"
 itertools = "0.9"
 log = "0.4"
 pest = "2.1.3"
 pest_derive = "2.1.0"
 proc-macro2 = "1.0.8"
 quote = "1.0.3"
+structopt = "0.3.16"
 syn = "1.0.17"
-which = { version = "3", optional = true }
-base64 = "0.12.1"
-comrak = "0.7"
-anyhow = "1.0"
 thiserror = "1.0"
-structopt = "0.3.17"
+which = { version = "3", optional = true }
 
 
 [dev-dependencies]

--- a/humblegen/Cargo.toml
+++ b/humblegen/Cargo.toml
@@ -12,7 +12,6 @@ description = "An experimental code-generator in the vain of protobuf, but a lit
 
 [dependencies]
 Inflector = "0.11.4"
-argh = "0.1.3"
 itertools = "0.9"
 log = "0.4"
 pest = "2.1.3"
@@ -25,6 +24,7 @@ base64 = "0.12.1"
 comrak = "0.7"
 anyhow = "1.0"
 thiserror = "1.0"
+structopt = "0.3.17"
 
 
 [dev-dependencies]

--- a/humblegen/src/cli.rs
+++ b/humblegen/src/cli.rs
@@ -1,5 +1,6 @@
 use anyhow::{self, Result};
 use std::{ops::Deref, path, str};
+use structopt::StructOpt;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -48,6 +49,18 @@ impl str::FromStr for Artifact {
     }
 }
 
+// This impl is necessary allow the usage of the structopt default_value attribute
+impl ToString for Artifact {
+    fn to_string(&self) -> String {
+        match self.0 {
+            // These strings have to match the ones in str::FromString
+            humblegen::Artifact::TypesOnly => "TYPES".to_string(),
+            humblegen::Artifact::ClientEndpoints => "CLIENT".to_string(),
+            humblegen::Artifact::ServerEndpoints => "SERVER".to_string(),
+        }
+    }
+}
+
 impl Deref for Artifact {
     type Target = humblegen::Artifact;
 
@@ -58,33 +71,22 @@ impl Deref for Artifact {
 
 /// Command-line arguments
 // TODO: turn into enum separating language backends from docs backend, docs backend does not need a gen_server and gen_client field
-#[derive(argh::FromArgs)]
-#[argh(description = "generate code from humble protocol spec")]
+#[derive(StructOpt)]
+#[structopt(about = "generate code from humble protocol spec")]
 pub(crate) struct CliArgs {
     /// language to generate code for
-    #[argh(
-        option,
-        short = 'l',
-        long = "language",
-        from_str_fn(str::FromStr::from_str)
-    )]
+    #[structopt(short = "l", long = "language")]
     pub(crate) backend: Backend,
     /// generate REST endpoints for a server
-    #[argh(
-        option,
-        short = 'a',
-        from_str_fn(str::FromStr::from_str),
-        default = "Artifact::default()"
-    )]
+    #[structopt(short = "a", long = "artifacts", default_value)]
     pub(crate) artifacts: Artifact,
     /// input path to humble file
-    #[argh(positional)]
     pub(crate) input: path::PathBuf,
     /// input path to humble file
-    #[argh(option, short = 'o')]
+    #[structopt(short = "o", long = "output")]
     pub(crate) output: path::PathBuf,
     /// prefix to be used in elm module declarations
-    #[argh(option, default = "\"Api\".to_owned()")]
+    #[structopt(long, default_value = "\"Api\"")]
     pub(crate) elm_module_root: String,
 }
 

--- a/humblegen/src/main.rs
+++ b/humblegen/src/main.rs
@@ -3,9 +3,10 @@
 mod cli;
 
 use anyhow::{Context, Result};
+use structopt::StructOpt;
 
 fn main() -> Result<()> {
-    let args: cli::CliArgs = argh::from_env();
+    let args = cli::CliArgs::from_args();
 
     let spec_file = std::fs::File::open(&args.input).context(format!(
         "unable to open specification file {:?}",


### PR DESCRIPTION
This PR replaces argh with structopt. This change allows more valid inputs than before and resolves the FIXME to make artifacts an option.