### PR TITLE
Show body type in request properties

### DIFF
--- a/humblegen/src/backend/docs.rs
+++ b/humblegen/src/backend/docs.rs
@@ -278,7 +278,7 @@ impl Context {
                         .as_ref()
                         .map(|q| { format!("?{}", Self::type_ident_to_html(q)) })
                         .unwrap_or_default(),
-                    //endpointProperties = "",
+                    endpointProperties = Self::properties_to_html(&endpoint.route),
                 )
             })
             .join("\n")
@@ -374,6 +374,16 @@ impl Context {
             .join("");
 
         format!("{}{}", route.http_method_as_str(), component_str)
+    }
+
+    pub fn properties_to_html(route: &ast::ServiceRoute) -> String {
+        match route.request_body() {
+            Some(type_ident) => format!(
+                include_str!("docs/endpoint-properties.html"),
+                endpointBody = Self::type_ident_to_html(type_ident),
+            ),
+            None => "".to_owned(),
+        }
     }
 
     // FIXME: Consider renaming this

--- a/humblegen/src/backend/docs/endpoint-properties.html
+++ b/humblegen/src/backend/docs/endpoint-properties.html
@@ -1,2 +1,4 @@
-<h2 class="endpoint--properties">Properties</h2>
-{endpointProperties}
+<div class="endpoint--properties">
+    <h2 class="endpoint--properties-title">Properties</h2>
+    <div class="endpoint--body-type">{endpointBody}</div>
+</div>

--- a/humblegen/src/backend/docs/endpoint.html
+++ b/humblegen/src/backend/docs/endpoint.html
@@ -10,5 +10,6 @@
     </h1>
     <div class="details">
         <div class="endpoint--description">{endpointDescription}</div>
+        {endpointProperties}
     </div>
 </section>

--- a/humblegen/src/backend/docs/main.css
+++ b/humblegen/src/backend/docs/main.css
@@ -120,7 +120,7 @@ body {
     padding: 1em 0 .2em 0;
 }
 
-.endpoint--return-type, .endpoint--properties {
+.endpoint--return-type, .endpoint--properties-title {
     padding-left: .4em; 
     font-weight: bold;
     flex-grow: 1;
@@ -147,6 +147,18 @@ body {
     padding-right: 0.3em;
 }
 
+.endpoint--properties .endpoint--body-type {
+    padding-left: .8em;
+    padding-top: .4em;
+    font-family: 'Roboto Mono', monospace;
+    font-size: .8em;
+}
+
+.endpoint--properties .endpoint--body-type::before {
+    content: "Body:";
+    display: inline-block;
+    padding-right: 0.3em;
+}
 
 .fold-open .endpoint--method-and-route, .fold-open .userDefinedType--kind-and-name {
     background: #d3d3d329


### PR DESCRIPTION
Extend docs generator by adding properties to any requests with a request body.

Due to my lack of css knowledge I wasn't able to get the links to look nice. So someone should probably add that one line which solves this, before I spend an unnecessarily long amount of time on this. 

![image](https://user-images.githubusercontent.com/23488661/93766430-af5fe980-fc16-11ea-8462-a498b5520bae.png)
